### PR TITLE
feat: #28 adding `showAccesses` flag

### DIFF
--- a/api/shortener.go
+++ b/api/shortener.go
@@ -44,7 +44,7 @@ func (h *shortenerHandler) Group() *string {
 // @Param id path string true "ShortLink ID"
 // @Param from query string false "accesses from date 'YYYY-mm-dd'"
 // @Param until query string false "accesses until date 'YYYY-mm-dd'"
-// @Param showAccesses query boolean false "display accesses column"
+// @Param show_accesses query boolean false "display accesses column"
 // @Success 200 {object} entity.Shorty "response"
 // @Failure 400 {object} response.FailureResponse "error"
 // @Failure 404 {object} response.FailureResponse "not found"
@@ -61,13 +61,13 @@ func (h *shortenerHandler) GetLinkInformation(c *gin.Context) {
 	from := c.Query("from")
 	until := c.Query("until")
 
-	showAccessesStr := c.Query("showAccesses")
+	showAccessesStr := c.Query("show_accesses")
 	showAccesses := true
 	if showAccessesStr != "" {
 		var err error
 		showAccesses, err = strconv.ParseBool(showAccessesStr)
 		if err != nil {
-			c.JSON(400, gin.H{"error": "Invalid value for showAccesses"})
+			c.JSON(http.StatusBadRequest, "invalid value for show_accesses")
 			return
 		}
 	}

--- a/api/shortener.go
+++ b/api/shortener.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/doutorfinancas/pun-sho/api/response"
 	"github.com/gin-gonic/gin"
@@ -43,6 +44,7 @@ func (h *shortenerHandler) Group() *string {
 // @Param id path string true "ShortLink ID"
 // @Param from query string false "accesses from date 'YYYY-mm-dd'"
 // @Param until query string false "accesses until date 'YYYY-mm-dd'"
+// @Param showAccesses query boolean false "display accesses column"
 // @Success 200 {object} entity.Shorty "response"
 // @Failure 400 {object} response.FailureResponse "error"
 // @Failure 404 {object} response.FailureResponse "not found"
@@ -58,7 +60,18 @@ func (h *shortenerHandler) GetLinkInformation(c *gin.Context) {
 	parsed := uuid.MustParse(id)
 	from := c.Query("from")
 	until := c.Query("until")
-	shorty, err := h.shortySvc.FindShortyByID(parsed, from, until)
+
+	showAccessesStr := c.Query("showAccesses")
+	showAccesses := true
+	if showAccessesStr != "" {
+		var err error
+		showAccesses, err = strconv.ParseBool(showAccessesStr)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "Invalid value for showAccesses"})
+			return
+		}
+	}
+	shorty, err := h.shortySvc.FindShortyByID(parsed, from, until, showAccesses)
 	if err != nil {
 		c.JSON(http.StatusNotFound, "shorty not found")
 		return
@@ -161,7 +174,7 @@ func (h *shortenerHandler) EditLink(c *gin.Context) {
 		return
 	}
 
-	shorty, err := h.shortySvc.FindShortyByID(uuid.MustParse(id), "", "")
+	shorty, err := h.shortySvc.FindShortyByID(uuid.MustParse(id), "", "", true)
 	if err != nil {
 		c.JSON(http.StatusNotFound, "shorty not found")
 		return

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -161,6 +161,12 @@
                         "description": "accesses until date 'YYYY-mm-dd'",
                         "name": "until",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "display accesses column",
+                        "name": "showAccesses",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -279,7 +279,7 @@ paths:
         type: string
       - description: display accesses column
         in: query
-        name: showAccesses
+        name: show_accesses
         type: boolean
       responses:
         "200":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -277,6 +277,10 @@ paths:
         in: query
         name: until
         type: string
+      - description: display accesses column
+        in: query
+        name: showAccesses
+        type: boolean
       responses:
         "200":
           description: response

--- a/entity/shorty_model.go
+++ b/entity/shorty_model.go
@@ -14,7 +14,7 @@ type Shorty struct {
 	RedirectionLimit *int           `json:"redirection_limit" gorm:"column:redirection_limit"`
 	CreatedAt        *time.Time     `json:"created_at" gorm:"column:created_at"`
 	DeletedAt        *time.Time     `json:"deleted_at" gorm:"column:deleted_at"`
-	ShortyAccesses   []ShortyAccess `json:"accesses" gorm:"-"`
+	ShortyAccesses   []ShortyAccess `json:"accesses,omitempty" gorm:"-"`
 	ShortLink        string         `json:"short_link" gorm:"-"`
 	Visits           int            `json:"visits" gorm:"-"`
 	RedirectCount    int            `json:"redirects" gorm:"-"`

--- a/service/shorty.go
+++ b/service/shorty.go
@@ -170,7 +170,7 @@ func (s *ShortyService) List(limit, offset int) ([]*entity.Shorty, error) {
 	return shorties, nil
 }
 
-func (s *ShortyService) FindShortyByID(id uuid.UUID, from, until string) (*entity.Shorty, error) {
+func (s *ShortyService) FindShortyByID(id uuid.UUID, from, until string, showAccesses bool) (*entity.Shorty, error) {
 	m := &entity.Shorty{
 		ID: id,
 	}
@@ -192,7 +192,9 @@ func (s *ShortyService) FindShortyByID(id uuid.UUID, from, until string) (*entit
 
 		sh := s.FindAllAccessesByShortyIDAndDateRange(id, &fromTime, &untilTime)
 
-		m.ShortyAccesses = sh
+		if showAccesses {
+			m.ShortyAccesses = sh
+		}
 
 		m.Visits = len(sh)
 		m.RedirectCount = CountRedirects(sh)
@@ -202,7 +204,9 @@ func (s *ShortyService) FindShortyByID(id uuid.UUID, from, until string) (*entit
 
 	sh := s.FindAllAccessesByShortyID(id)
 
-	m.ShortyAccesses = sh
+	if showAccesses {
+		m.ShortyAccesses = sh
+	}
 
 	m.Visits = len(sh)
 	m.RedirectCount = CountRedirects(sh)


### PR DESCRIPTION
Create flag to hide or display the accesses attribute in the short link details request.

Example request:
`http://localhost:8080/api/v1/short/{shortId}?showAccesses=true`