### PR TITLE
fix: allow social media bots to access shortlinks for previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ DB_ADAPTOR=cockroach
 QR_PNG_LOGO=./img/logo_df.png
 SSL_MODE=full-verify
 PUBLIC_ID_LENGTH=7
+ALLOWED_SOCIAL_BOTS=facebookexternalhit,facebot,googlebot,linkedinbot,twitterbot,instagram,instagrambot,whatsapp,slackbot,telegrambot,discordbot,pinterestbot,redditbot,skypeuri,applebot,bingbot,yandexbot

--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,7 @@ DB_ADAPTOR=cockroach
 QR_PNG_LOGO=./img/logo_df.png
 SSL_MODE=full-verify
 PUBLIC_ID_LENGTH=7
-ALLOWED_SOCIAL_BOTS=facebookexternalhit,facebot,googlebot,linkedinbot,twitterbot,instagram,instagrambot,whatsapp,slackbot,telegrambot,discordbot,pinterestbot,redditbot,skypeuri,applebot,bingbot,yandexbot
+# Social media bots allowed to access shortlinks for previews (comma-separated)
+# Leave empty to block all bots, or specify only the ones you want to allow
+# Example: ALLOWED_SOCIAL_BOTS=facebookexternalhit,googlebot,linkedinbot
+ALLOWED_SOCIAL_BOTS=

--- a/api/config.go
+++ b/api/config.go
@@ -37,17 +37,16 @@ func (c *Config) GetDatabaseConfig() *database.Config {
 // GetConfiguredSocialBots converts the configuration string into a slice of configured bots
 // Returns empty slice if not configured, giving full control to each environment
 func (c *Config) GetConfiguredSocialBots() []string {
-	if c.AllowedSocialBots == "" {
-		return []string{} // No bots allowed by default - explicit configuration required
-	}
-
-	bots := strings.Split(c.AllowedSocialBots, ",")
-	var trimmedBots []string
-	for _, bot := range bots {
-		trimmed := strings.TrimSpace(bot)
-		if trimmed != "" {
-			trimmedBots = append(trimmedBots, trimmed)
+	if c.AllowedSocialBots != "" {
+		bots := strings.Split(c.AllowedSocialBots, ",")
+		var trimmedBots []string
+		for _, bot := range bots {
+			trimmed := strings.TrimSpace(bot)
+			if trimmed != "" {
+				trimmedBots = append(trimmedBots, trimmed)
+			}
 		}
+		return trimmedBots
 	}
-	return trimmedBots
+	return []string{} // No bots allowed by default - explicit configuration required
 }

--- a/api/config.go
+++ b/api/config.go
@@ -34,29 +34,11 @@ func (c *Config) GetDatabaseConfig() *database.Config {
 	}
 }
 
-// GetAllowedSocialBots converts the configuration string into a slice of allowed bots
-func (c *Config) GetAllowedSocialBots() []string {
+// GetConfiguredSocialBots converts the configuration string into a slice of configured bots
+// Returns empty slice if not configured, giving full control to each environment
+func (c *Config) GetConfiguredSocialBots() []string {
 	if c.AllowedSocialBots == "" {
-		// Default list of social media bots if not configured
-		return []string{
-			"facebookexternalhit",
-			"facebot",
-			"googlebot",
-			"linkedinbot",
-			"twitterbot",
-			"instagram",
-			"instagrambot",
-			"whatsapp",
-			"slackbot",
-			"telegrambot",
-			"discordbot",
-			"pinterestbot",
-			"redditbot",
-			"skypeuri",
-			"applebot",
-			"bingbot",
-			"yandexbot",
-		}
+		return []string{} // No bots allowed by default - explicit configuration required
 	}
 
 	bots := strings.Split(c.AllowedSocialBots, ",")

--- a/api/config.go
+++ b/api/config.go
@@ -34,10 +34,10 @@ func (c *Config) GetDatabaseConfig() *database.Config {
 	}
 }
 
-// GetAllowedSocialBots converte a string de configuração numa slice de bots permitidos
+// GetAllowedSocialBots converts the configuration string into a slice of allowed bots
 func (c *Config) GetAllowedSocialBots() []string {
 	if c.AllowedSocialBots == "" {
-		// Lista padrão de bots de redes sociais se não estiver configurado
+		// Default list of social media bots if not configured
 		return []string{
 			"facebookexternalhit",
 			"facebot",

--- a/api/config.go
+++ b/api/config.go
@@ -1,22 +1,25 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/doutorfinancas/pun-sho/database"
 )
 
 type Config struct {
-	Port           int    `env:"API_PORT"`
-	Token          string `env:"AUTH_TOKEN"`
-	HostName       string `env:"HOST_NAME"`
-	UnknownPage    string `env:"UNKNOWN_PAGE"`
-	QRLogo         string `env:"QR_PNG_LOGO"`
-	DBUsername     string `env:"DB_USERNAME"`
-	DBPassword     string `env:"DB_PASSWORD"`
-	DBName         string `env:"DB_NAME"`
-	DBHost         string `env:"DB_URL"`
-	DBPort         int    `env:"DB_PORT"`
-	SSLMode        string `env:"SSL_MODE"`
-	PublicIDLength int    `env:"PUBLIC_ID_LENGTH"`
+	Port              int    `env:"API_PORT"`
+	Token             string `env:"AUTH_TOKEN"`
+	HostName          string `env:"HOST_NAME"`
+	UnknownPage       string `env:"UNKNOWN_PAGE"`
+	QRLogo            string `env:"QR_PNG_LOGO"`
+	DBUsername        string `env:"DB_USERNAME"`
+	DBPassword        string `env:"DB_PASSWORD"`
+	DBName            string `env:"DB_NAME"`
+	DBHost            string `env:"DB_URL"`
+	DBPort            int    `env:"DB_PORT"`
+	SSLMode           string `env:"SSL_MODE"`
+	PublicIDLength    int    `env:"PUBLIC_ID_LENGTH"`
+	AllowedSocialBots string `env:"ALLOWED_SOCIAL_BOTS"`
 }
 
 func (c *Config) GetDatabaseConfig() *database.Config {
@@ -29,4 +32,40 @@ func (c *Config) GetDatabaseConfig() *database.Config {
 		SSLMode:      c.SSLMode,
 		DatabaseType: database.PostGreType,
 	}
+}
+
+// GetAllowedSocialBots converte a string de configuração numa slice de bots permitidos
+func (c *Config) GetAllowedSocialBots() []string {
+	if c.AllowedSocialBots == "" {
+		// Lista padrão de bots de redes sociais se não estiver configurado
+		return []string{
+			"facebookexternalhit",
+			"facebot",
+			"googlebot",
+			"linkedinbot",
+			"twitterbot",
+			"instagram",
+			"instagrambot",
+			"whatsapp",
+			"slackbot",
+			"telegrambot",
+			"discordbot",
+			"pinterestbot",
+			"redditbot",
+			"skypeuri",
+			"applebot",
+			"bingbot",
+			"yandexbot",
+		}
+	}
+
+	bots := strings.Split(c.AllowedSocialBots, ",")
+	var trimmedBots []string
+	for _, bot := range bots {
+		trimmed := strings.TrimSpace(bot)
+		if trimmed != "" {
+			trimmedBots = append(trimmedBots, trimmed)
+		}
+	}
+	return trimmedBots
 }

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_GetConfiguredSocialBots(t *testing.T) {
+	tests := []struct {
+		name              string
+		allowedSocialBots string
+		expected          []string
+	}{
+		{
+			name:              "Empty configuration should return empty slice",
+			allowedSocialBots: "",
+			expected:          []string{},
+		},
+		{
+			name:              "Single bot configuration",
+			allowedSocialBots: "facebookexternalhit",
+			expected:          []string{"facebookexternalhit"},
+		},
+		{
+			name:              "Multiple bots configuration",
+			allowedSocialBots: "facebookexternalhit,googlebot,linkedinbot",
+			expected:          []string{"facebookexternalhit", "googlebot", "linkedinbot"},
+		},
+		{
+			name:              "Configuration with spaces should be trimmed",
+			allowedSocialBots: " facebookexternalhit , googlebot , linkedinbot ",
+			expected:          []string{"facebookexternalhit", "googlebot", "linkedinbot"},
+		},
+		{
+			name:              "Configuration with empty values should be filtered",
+			allowedSocialBots: "facebookexternalhit,,googlebot,",
+			expected:          []string{"facebookexternalhit", "googlebot"},
+		},
+		{
+			name:              "Instagram bots configuration",
+			allowedSocialBots: "instagram,instagrambot",
+			expected:          []string{"instagram", "instagrambot"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				AllowedSocialBots: tt.allowedSocialBots,
+			}
+			result := config.GetConfiguredSocialBots()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		cfg.HostName,
 		cfg.QRLogo,
 		cfg.PublicIDLength,
-		cfg.GetAllowedSocialBots(),
+		cfg.GetConfiguredSocialBots(),
 	)
 
 	a := api.NewAPI(log, cfg, shortySvc, qrSvc)

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 		cfg.HostName,
 		cfg.QRLogo,
 		cfg.PublicIDLength,
+		cfg.GetAllowedSocialBots(),
 	)
 
 	a := api.NewAPI(log, cfg, shortySvc, qrSvc)

--- a/service/shorty.go
+++ b/service/shorty.go
@@ -25,7 +25,7 @@ const (
 	TransparentBackground = "transparent"
 )
 
-// isSocialMediaBot verifica se o User-Agent corresponde a um bot de rede social permitido
+// isSocialMediaBot checks if the User-Agent corresponds to an allowed social media bot
 func (s *ShortyService) isSocialMediaBot(userAgent string) bool {
 	userAgentLower := strings.ToLower(userAgent)
 	for _, bot := range s.allowedSocialBots {

--- a/service/shorty.go
+++ b/service/shorty.go
@@ -26,10 +26,20 @@ const (
 )
 
 // isSocialMediaBot checks if the User-Agent corresponds to an allowed social media bot
+// Uses precise matching to prevent false positives from malicious user agents
 func (s *ShortyService) isSocialMediaBot(userAgent string) bool {
 	userAgentLower := strings.ToLower(userAgent)
+
 	for _, bot := range s.allowedSocialBots {
-		if strings.Contains(userAgentLower, bot) {
+		botLower := strings.ToLower(bot)
+
+		// Check for exact match or bot name followed by common separators
+		// This prevents false positives like "malicious-facebookexternalhit-exploit"
+		if userAgentLower == botLower ||
+			strings.HasPrefix(userAgentLower, botLower+"/") ||
+			strings.HasPrefix(userAgentLower, botLower+" ") ||
+			strings.Contains(userAgentLower, " "+botLower+"/") ||
+			strings.Contains(userAgentLower, " "+botLower+" ") {
 			return true
 		}
 	}

--- a/service/shorty_test.go
+++ b/service/shorty_test.go
@@ -221,6 +221,52 @@ func TestShortyService_IsSocialMediaBot(t *testing.T) {
 			userAgent:      "Mozilla/5.0 (compatible; GoogleBot/2.1; +http://www.google.com/bot.html)",
 			expectedResult: true,
 		},
+		{
+			name:           "Case insensitive - Config with mixed case",
+			allowedBots:    []string{"FacebookExternalHit"},
+			userAgent:      "facebookexternalhit/1.1",
+			expectedResult: true,
+		},
+
+		// Test case 5: Security - False positive prevention
+		{
+			name:           "Security - Malicious bot with prefix should be blocked",
+			allowedBots:    []string{"facebookexternalhit"},
+			userAgent:      "malicious-facebookexternalhit-exploit",
+			expectedResult: false,
+		},
+		{
+			name:           "Security - Malicious bot with suffix should be blocked",
+			allowedBots:    []string{"googlebot"},
+			userAgent:      "googlebot-malicious/1.0",
+			expectedResult: false,
+		},
+		{
+			name:           "Security - Bot name in middle should be blocked",
+			allowedBots:    []string{"linkedinbot"},
+			userAgent:      "evil-linkedinbot-scraper",
+			expectedResult: false,
+		},
+
+		// Test case 6: Valid bot patterns that should work
+		{
+			name:           "Valid - Bot with version",
+			allowedBots:    []string{"facebookexternalhit"},
+			userAgent:      "facebookexternalhit/1.1",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid - Bot with space",
+			allowedBots:    []string{"googlebot"},
+			userAgent:      "Mozilla/5.0 (compatible; googlebot/2.1; +http://www.google.com/bot.html)",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid - Exact bot name",
+			allowedBots:    []string{"instagrambot"},
+			userAgent:      "instagrambot",
+			expectedResult: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/service/shorty_test.go
+++ b/service/shorty_test.go
@@ -81,8 +81,9 @@ func TestShortyService_Create(t *testing.T) {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				s := &ShortyService{
-					hostName:         tt.fields.hostName,
-					shortyRepository: tt.fields.shortyRepository,
+					hostName:          tt.fields.hostName,
+					shortyRepository:  tt.fields.shortyRepository,
+					allowedSocialBots: []string{}, // Lista vazia para teste
 				}
 				got, err := s.Create(tt.args.req)
 				if (err != nil) != tt.wantErr {
@@ -154,6 +155,93 @@ func TestCountRedirects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, CountRedirects(tt.args.accesses), "CountRedirects(%v)", tt.args.accesses)
+		})
+	}
+}
+
+func TestShortyService_IsSocialMediaBot(t *testing.T) {
+	// Criar um ShortyService com a lista padrão de bots
+	service := &ShortyService{
+		allowedSocialBots: []string{
+			"facebookexternalhit",
+			"facebot",
+			"googlebot",
+			"linkedinbot",
+			"twitterbot",
+			"instagram",
+			"instagrambot",
+			"whatsapp",
+			"slackbot",
+			"telegrambot",
+			"discordbot",
+			"pinterestbot",
+			"redditbot",
+			"skypeuri",
+			"applebot",
+			"bingbot",
+			"yandexbot",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		userAgent string
+		want      bool
+	}{
+		{
+			name:      "Facebook External Hit",
+			userAgent: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+			want:      true,
+		},
+		{
+			name:      "Google Bot",
+			userAgent: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+			want:      true,
+		},
+		{
+			name:      "LinkedIn Bot",
+			userAgent: "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)",
+			want:      true,
+		},
+		{
+			name:      "Twitter Bot",
+			userAgent: "Twitterbot/1.0",
+			want:      true,
+		},
+		{
+			name:      "Regular Chrome Browser",
+			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+			want:      false,
+		},
+		{
+			name:      "Regular Safari Browser",
+			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15",
+			want:      false,
+		},
+		{
+			name:      "Malicious Bot",
+			userAgent: "BadBot/1.0",
+			want:      false,
+		},
+		{
+			name:      "WhatsApp Bot",
+			userAgent: "WhatsApp/2.19.81 A",
+			want:      true,
+		},
+		{
+			name:      "Instagram Bot",
+			userAgent: "Instagram 76.0.0.15.395 Android (24/7.0; 640dpi; 1440x2560; samsung; SM-G930F; herolte; samsungexynos8890; en_US; 138226743)",
+			want:      true,
+		},
+		{
+			name:      "Instagram Bot 2",
+			userAgent: "instagrambot",
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, service.isSocialMediaBot(tt.userAgent))
 		})
 	}
 }

--- a/service/shorty_test.go
+++ b/service/shorty_test.go
@@ -83,7 +83,7 @@ func TestShortyService_Create(t *testing.T) {
 				s := &ShortyService{
 					hostName:          tt.fields.hostName,
 					shortyRepository:  tt.fields.shortyRepository,
-					allowedSocialBots: []string{}, // Lista vazia para teste
+					allowedSocialBots: []string{}, // Empty list for testing
 				}
 				got, err := s.Create(tt.args.req)
 				if (err != nil) != tt.wantErr {
@@ -160,7 +160,7 @@ func TestCountRedirects(t *testing.T) {
 }
 
 func TestShortyService_IsSocialMediaBot(t *testing.T) {
-	// Criar um ShortyService com a lista padrão de bots
+	// Create a ShortyService with the default list of bots
 	service := &ShortyService{
 		allowedSocialBots: []string{
 			"facebookexternalhit",


### PR DESCRIPTION
- Fix issue where social media crawlers (Facebook, LinkedIn, Google, Instagram, etc.) were blocked from accessing shortlinks, causing 404 previews on social platforms
- Add configurable whitelist of allowed social media bots via ALLOWED_SOCIAL_BOTS env var
- Maintain security by continuing to block non-whitelisted bots
- Add comprehensive tests for social media bot detection
- Social media previews now work correctly while protecting against malicious bots

Resolves shortlink preview issues on Facebook Sharing Debugger and other platforms.